### PR TITLE
Add omitAggregateTypes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,14 @@ Default: `["args", "inputs", "outputs", "models", "enums"]`
 
 #### `omitModelsCount`
 
-Omit `_count` field from models.  
-Type: `boolean`  
+Omit `_count` field from models.
+Type: `boolean`
+Default: `false`
+
+#### `omitAggregateTypes`
+
+Skip generation of aggregate output and argument types.
+Type: `boolean`
 Default: `false`
 
 #### `purgeOutput`

--- a/src/handlers/args-type.ts
+++ b/src/handlers/args-type.ts
@@ -27,6 +27,13 @@ export function argsType(field: SchemaField, args: EventArguments) {
     }
   }
 
+  if (
+    args.config.omitAggregateTypes &&
+    (className.endsWith('AggregateArgs') || className.endsWith('GroupByArgs'))
+  ) {
+    return;
+  }
+
   const inputType: InputType = {
     // eslint-disable-next-line unicorn/no-null
     constraints: { maxNumFields: null, minNumFields: null },

--- a/src/handlers/create-aggregate-input.ts
+++ b/src/handlers/create-aggregate-input.ts
@@ -8,6 +8,9 @@ import { EventArguments, InputType, OutputType } from '../types';
 export function createAggregateInput(
   args: EventArguments & { outputType: OutputType },
 ) {
+  if (args.config.omitAggregateTypes) {
+    return;
+  }
   const { eventEmitter, outputType } = args;
   const className = `${outputType.name}Input`;
 

--- a/src/handlers/output-type.ts
+++ b/src/handlers/output-type.ts
@@ -34,6 +34,9 @@ export function outputType(outputType: OutputType, args: EventArguments) {
   outputType.name = getOutputTypeName(outputType.name);
 
   if (isAggregateOutput) {
+    if (config.omitAggregateTypes) {
+      return;
+    }
     eventEmitter.emitSync('AggregateOutput', { ...args, outputType });
   }
 

--- a/src/helpers/create-config.ts
+++ b/src/helpers/create-config.ts
@@ -132,6 +132,7 @@ export function createConfig(data: Record<string, unknown>) {
     emitCompiled: toBoolean(config.emitCompiled),
     emitBlocks: createEmitBlocks(config.emitBlocks as EmitBlocksOption[]),
     omitModelsCount: toBoolean(config.omitModelsCount),
+    omitAggregateTypes: toBoolean(config.omitAggregateTypes),
     $warnings,
     fields,
     purgeOutput: toBoolean(config.purgeOutput),

--- a/src/test/generate.spec.ts
+++ b/src/test/generate.spec.ts
@@ -2487,3 +2487,23 @@ describe('unsafeCompatibleWhereUniqueInput', () => {
     expect(emailName.property?.hasExclamationToken).toBe(true);
   });
 });
+
+describe('omit aggregate types', () => {
+  before(async () => {
+    ({ project, sourceFiles } = await testGenerate({
+      options: [
+        `outputFilePattern = "{name}.{type}.ts"`,
+        `omitAggregateTypes = true`,
+      ],
+      schema: `model User { id Int @id }`,
+    }));
+  });
+
+  it('should not emit aggregate related files', () => {
+    const filePaths = sourceFiles.map(s => s.getFilePath().slice(1));
+    const aggregateFiles = filePaths.filter(p =>
+      /-aggregate\.|aggregate-|group-by/.test(p),
+    );
+    expect(aggregateFiles).toHaveLength(0);
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,9 @@ export type TypeRecord = Partial<{
   graphqlModule: string;
 }>;
 
-export type GeneratorConfiguration = ReturnType<typeof createConfig>;
+export type GeneratorConfiguration = ReturnType<typeof createConfig> & {
+  omitAggregateTypes: boolean;
+};
 
 export type EventArguments = {
   schema: Schema;


### PR DESCRIPTION
## Summary
- support `omitAggregateTypes` in configuration and types
- skip generating aggregate related types when option is enabled
- document new generator option
- test absence of aggregate files when configured

## Testing
- `npm test` *(fails: Cannot find module 'eslint')*

------
https://chatgpt.com/codex/tasks/task_e_685ead290a8883328ad2c55b3281e56f